### PR TITLE
Add persistence to DAQ components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [0.4.0] - 2020-03-04
 ### Added
 - [#80](https://github.com/plotly/dash-daq/pull/80) Added `theme` prop to `GraduatedBar` component.
+- [#105](https://github.com/plotly/dash-daq/pull/105) Added [persistence](https://dash.plotly.com/persistence) for
+components BooleanSwitch, ColorPicker, Knob, NumericInput, PowerButton, PrecisionInput, Slider and ToggleSwitch
 
 ### Changed
 - [#91](https://github.com/plotly/dash-daq/pull/91) Renamed async modules with hyphen `-` instead of tilde `~`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,16 @@ Changelog](http://keepachangelog.com/en/1.0.0/) and this project
 adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [#105](https://github.com/plotly/dash-daq/pull/105) Added [persistence](https://dash.plotly.com/persistence) for
+components BooleanSwitch, ColorPicker, Knob, NumericInput, PowerButton, PrecisionInput, Slider and ToggleSwitch
+
+### Changed
 - [#92](https://github.com/plotly/dash-daq/pull/92) Update from React 16.8.6 to 16.13.0
 
 ## [0.4.0] - 2020-03-04
 ### Added
 - [#80](https://github.com/plotly/dash-daq/pull/80) Added `theme` prop to `GraduatedBar` component.
-- [#105](https://github.com/plotly/dash-daq/pull/105) Added [persistence](https://dash.plotly.com/persistence) for
-components BooleanSwitch, ColorPicker, Knob, NumericInput, PowerButton, PrecisionInput, Slider and ToggleSwitch
 
 ### Changed
 - [#91](https://github.com/plotly/dash-daq/pull/91) Renamed async modules with hyphen `-` instead of tilde `~`

--- a/src/components/BooleanSwitch.react.js
+++ b/src/components/BooleanSwitch.react.js
@@ -47,7 +47,9 @@ BooleanSwitch.defaultProps = {
   on: false,
   vertical: false,
   theme: light,
-  labelPosition: 'top'
+  labelPosition: 'top',
+  persisted_props: ['on'],
+  persistence_type: 'local'
 };
 
 BooleanSwitch.propTypes = {
@@ -120,7 +122,32 @@ BooleanSwitch.propTypes = {
    * Dash-assigned callback that gets fired when
    * switch is toggled.
    */
-  setProps: PropTypes.func
+  setProps: PropTypes.func,
+
+  /**
+   * Used to allow user interactions in this component to be persisted when
+   * the component - or the page - is refreshed. If `persisted` is truthy and
+   * hasn't changed from its previous value, a `value` that the user has
+   * changed while using the app will keep that change, as long as
+   * the new `value` also matches what was given originally.
+   * Used in conjunction with `persistence_type`.
+   */
+  persistence: PropTypes.oneOfType([PropTypes.bool, PropTypes.string, PropTypes.number]),
+
+  /**
+   * Properties whose user interactions will persist after refreshing the
+   * component or the page. Since only `on` is allowed this prop can
+   * normally be ignored.
+   */
+  persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['on'])),
+
+  /**
+   * Where persisted user changes will be stored:
+   * memory: only kept in memory, reset on page refresh.
+   * local: window.localStorage, data is kept after the browser quit.
+   * session: window.sessionStorage, data is cleared once the browser quit.
+   */
+  persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
 export default withTheme(BooleanSwitch);

--- a/src/components/BooleanSwitch.react.js
+++ b/src/components/BooleanSwitch.react.js
@@ -150,4 +150,6 @@ BooleanSwitch.propTypes = {
   persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
-export default withTheme(BooleanSwitch);
+const ThemedBooleanSwitch = withTheme(BooleanSwitch);
+ThemedBooleanSwitch.defaultProps = BooleanSwitch.defaultProps;
+export default ThemedBooleanSwitch;

--- a/src/components/ColorPicker.react.js
+++ b/src/components/ColorPicker.react.js
@@ -22,7 +22,9 @@ export default class ColorPicker extends Component {
 ColorPicker.defaultProps = {
   size: 225,
   theme: light,
-  labelPosition: 'top'
+  labelPosition: 'top',
+  persisted_props: ['value'],
+  persistence_type: 'local'
 };
 
 ColorPicker.propTypes = {
@@ -104,7 +106,32 @@ ColorPicker.propTypes = {
   /**
    * Style to apply to the root component element
    */
-  style: PropTypes.object
+  style: PropTypes.object,
+
+  /**
+   * Used to allow user interactions in this component to be persisted when
+   * the component - or the page - is refreshed. If `persisted` is truthy and
+   * hasn't changed from its previous value, a `value` that the user has
+   * changed while using the app will keep that change, as long as
+   * the new `value` also matches what was given originally.
+   * Used in conjunction with `persistence_type`.
+   */
+  persistence: PropTypes.oneOfType([PropTypes.bool, PropTypes.string, PropTypes.number]),
+
+  /**
+   * Properties whose user interactions will persist after refreshing the
+   * component or the page. Since only `value` is allowed this prop can
+   * normally be ignored.
+   */
+  persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['value'])),
+
+  /**
+   * Where persisted user changes will be stored:
+   * memory: only kept in memory, reset on page refresh.
+   * local: window.localStorage, data is kept after the browser quit.
+   * session: window.sessionStorage, data is cleared once the browser quit.
+   */
+  persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
 export const defaultProps = ColorPicker.defaultProps;

--- a/src/components/Knob.react.js
+++ b/src/components/Knob.react.js
@@ -347,4 +347,6 @@ Knob.propTypes = {
   persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
-export default withTheme(Knob);
+const ThemedKnob = withTheme(Knob);
+ThemedKnob.defaultProps = Knob.defaultProps;
+export default ThemedKnob;

--- a/src/components/Knob.react.js
+++ b/src/components/Knob.react.js
@@ -161,7 +161,9 @@ Knob.defaultProps = {
   min: 0,
   max: 10,
   theme: light,
-  labelPosition: 'top'
+  labelPosition: 'top',
+  persisted_props: ['value'],
+  persistence_type: 'local'
 };
 
 Knob.propTypes = {
@@ -317,7 +319,32 @@ Knob.propTypes = {
    * Dash-assigned callback that gets fired when selected
    * value changes.
    */
-  setProps: PropTypes.func
+  setProps: PropTypes.func,
+
+  /**
+   * Used to allow user interactions in this component to be persisted when
+   * the component - or the page - is refreshed. If `persisted` is truthy and
+   * hasn't changed from its previous value, a `value` that the user has
+   * changed while using the app will keep that change, as long as
+   * the new `value` also matches what was given originally.
+   * Used in conjunction with `persistence_type`.
+   */
+  persistence: PropTypes.oneOfType([PropTypes.bool, PropTypes.string, PropTypes.number]),
+
+  /**
+   * Properties whose user interactions will persist after refreshing the
+   * component or the page. Since only `value` is allowed this prop can
+   * normally be ignored.
+   */
+  persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['value'])),
+
+  /**
+   * Where persisted user changes will be stored:
+   * memory: only kept in memory, reset on page refresh.
+   * local: window.localStorage, data is kept after the browser quit.
+   * session: window.sessionStorage, data is cleared once the browser quit.
+   */
+  persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
 export default withTheme(Knob);

--- a/src/components/NumericInput.react.js
+++ b/src/components/NumericInput.react.js
@@ -207,4 +207,6 @@ NumericInput.propTypes = {
   persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
-export default withTheme(NumericInput);
+const ThemedNumericInput = withTheme(NumericInput);
+ThemedNumericInput.defaultProps = NumericInput.defaultProps;
+export default ThemedNumericInput;

--- a/src/components/NumericInput.react.js
+++ b/src/components/NumericInput.react.js
@@ -100,7 +100,9 @@ NumericInput.defaultProps = {
   min: 0,
   max: 10,
   theme: light,
-  labelPosition: 'top'
+  labelPosition: 'top',
+  persisted_props: ['value'],
+  persistence_type: 'local'
 };
 
 NumericInput.propTypes = {
@@ -177,7 +179,32 @@ NumericInput.propTypes = {
    * Dash-assigned callback that gets fired when selected
    * value changes.
    */
-  setProps: PropTypes.func
+  setProps: PropTypes.func,
+
+  /**
+   * Used to allow user interactions in this component to be persisted when
+   * the component - or the page - is refreshed. If `persisted` is truthy and
+   * hasn't changed from its previous value, a `value` that the user has
+   * changed while using the app will keep that change, as long as
+   * the new `value` also matches what was given originally.
+   * Used in conjunction with `persistence_type`.
+   */
+  persistence: PropTypes.oneOfType([PropTypes.bool, PropTypes.string, PropTypes.number]),
+
+  /**
+   * Properties whose user interactions will persist after refreshing the
+   * component or the page. Since only `value` is allowed this prop can
+   * normally be ignored.
+   */
+  persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['value'])),
+
+  /**
+   * Where persisted user changes will be stored:
+   * memory: only kept in memory, reset on page refresh.
+   * local: window.localStorage, data is kept after the browser quit.
+   * session: window.sessionStorage, data is cleared once the browser quit.
+   */
+  persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
 export default withTheme(NumericInput);

--- a/src/components/PowerButton.react.js
+++ b/src/components/PowerButton.react.js
@@ -176,4 +176,6 @@ PowerButton.propTypes = {
   persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
-export default withTheme(PowerButton);
+const ThemedPowerButton = withTheme(PowerButton);
+ThemedPowerButton.defaultProps = PowerButton.defaultProps;
+export default ThemedPowerButton;

--- a/src/components/PowerButton.react.js
+++ b/src/components/PowerButton.react.js
@@ -75,7 +75,9 @@ PowerButton.defaultProps = {
   on: false,
   theme: light,
   size: 48,
-  labelPosition: 'top'
+  labelPosition: 'top',
+  persisted_props: ['on'],
+  persistence_type: 'local'
 };
 
 PowerButton.propTypes = {
@@ -146,7 +148,32 @@ PowerButton.propTypes = {
    * Dash-assigned callback that gets fired when
    * button is clicked.
    */
-  setProps: PropTypes.func
+  setProps: PropTypes.func,
+
+  /**
+   * Used to allow user interactions in this component to be persisted when
+   * the component - or the page - is refreshed. If `persisted` is truthy and
+   * hasn't changed from its previous value, a `value` that the user has
+   * changed while using the app will keep that change, as long as
+   * the new `value` also matches what was given originally.
+   * Used in conjunction with `persistence_type`.
+   */
+  persistence: PropTypes.oneOfType([PropTypes.bool, PropTypes.string, PropTypes.number]),
+
+  /**
+   * Properties whose user interactions will persist after refreshing the
+   * component or the page. Since only `on` is allowed this prop can
+   * normally be ignored.
+   */
+  persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['on'])),
+
+  /**
+   * Where persisted user changes will be stored:
+   * memory: only kept in memory, reset on page refresh.
+   * local: window.localStorage, data is kept after the browser quit.
+   * session: window.sessionStorage, data is cleared once the browser quit.
+   */
+  persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
 export default withTheme(PowerButton);

--- a/src/components/PrecisionInput.react.js
+++ b/src/components/PrecisionInput.react.js
@@ -323,4 +323,6 @@ PrecisionInput.propTypes = {
   persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
-export default withTheme(PrecisionInput);
+const ThemedPrecisionInput = withTheme(PrecisionInput);
+ThemedPrecisionInput.defaultProps = PrecisionInput.defaultProps;
+export default ThemedPrecisionInput;

--- a/src/components/PrecisionInput.react.js
+++ b/src/components/PrecisionInput.react.js
@@ -211,7 +211,9 @@ PrecisionInput.defaultProps = {
   max: Number.MAX_SAFE_INTEGER,
   theme: light,
   labelPosition: 'top',
-  precision: 2
+  precision: 2,
+  persisted_props: ['value'],
+  persistence_type: 'local'
 };
 
 PrecisionInput.propTypes = {
@@ -293,7 +295,32 @@ PrecisionInput.propTypes = {
    * Dash-assigned callback that gets fired when selected
    * value changes.
    */
-  setProps: PropTypes.func
+  setProps: PropTypes.func,
+
+  /**
+   * Used to allow user interactions in this component to be persisted when
+   * the component - or the page - is refreshed. If `persisted` is truthy and
+   * hasn't changed from its previous value, a `value` that the user has
+   * changed while using the app will keep that change, as long as
+   * the new `value` also matches what was given originally.
+   * Used in conjunction with `persistence_type`.
+   */
+  persistence: PropTypes.oneOfType([PropTypes.bool, PropTypes.string, PropTypes.number]),
+
+  /**
+   * Properties whose user interactions will persist after refreshing the
+   * component or the page. Since only `value` is allowed this prop can
+   * normally be ignored.
+   */
+  persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['value'])),
+
+  /**
+   * Where persisted user changes will be stored:
+   * memory: only kept in memory, reset on page refresh.
+   * local: window.localStorage, data is kept after the browser quit.
+   * session: window.sessionStorage, data is cleared once the browser quit.
+   */
+  persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
 export default withTheme(PrecisionInput);

--- a/src/components/Slider.react.js
+++ b/src/components/Slider.react.js
@@ -26,7 +26,9 @@ Slider.defaultProps = {
   color: colors.DARKER_PRIMARY,
   min: 0,
   size: 265,
-  labelPosition: 'bottom'
+  labelPosition: 'bottom',
+  persisted_props: ['value'],
+  persistence_type: 'local'
 };
 
 Slider.propTypes = {
@@ -222,7 +224,31 @@ Slider.propTypes = {
   /**
    * Dash-assigned callback that gets fired when the value changes.
    */
-  setProps: PropTypes.func
+  setProps: PropTypes.func,
+  /**
+   * Used to allow user interactions in this component to be persisted when
+   * the component - or the page - is refreshed. If `persisted` is truthy and
+   * hasn't changed from its previous value, a `value` that the user has
+   * changed while using the app will keep that change, as long as
+   * the new `value` also matches what was given originally.
+   * Used in conjunction with `persistence_type`.
+   */
+  persistence: PropTypes.oneOfType([PropTypes.bool, PropTypes.string, PropTypes.number]),
+
+  /**
+   * Properties whose user interactions will persist after refreshing the
+   * component or the page. Since only `value` is allowed this prop can
+   * normally be ignored.
+   */
+  persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['value'])),
+
+  /**
+   * Where persisted user changes will be stored:
+   * memory: only kept in memory, reset on page refresh.
+   * local: window.localStorage, data is kept after the browser quit.
+   * session: window.sessionStorage, data is cleared once the browser quit.
+   */
+  persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
 export const defaultProps = Slider.defaultProps;

--- a/src/components/ToggleSwitch.react.js
+++ b/src/components/ToggleSwitch.react.js
@@ -289,4 +289,6 @@ ToggleSwitch.propTypes = {
   persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
-export default withTheme(ToggleSwitch);
+const ThemedToggleSwitch = withTheme(ToggleSwitch);
+ThemedToggleSwitch.defaultProps = ToggleSwitch.defaultProps;
+export default ThemedToggleSwitch;

--- a/src/components/ToggleSwitch.react.js
+++ b/src/components/ToggleSwitch.react.js
@@ -160,7 +160,9 @@ ToggleSwitch.defaultProps = {
   value: false,
   vertical: false,
   theme: light,
-  labelPosition: 'top'
+  labelPosition: 'top',
+  persisted_props: ['value'],
+  persistence_type: 'local'
 };
 
 ToggleSwitch.propTypes = {
@@ -259,7 +261,32 @@ ToggleSwitch.propTypes = {
    * Dash-assigned callback that gets fired when
    * switch is toggled.
    */
-  setProps: PropTypes.func
+  setProps: PropTypes.func,
+
+  /**
+   * Used to allow user interactions in this component to be persisted when
+   * the component - or the page - is refreshed. If `persisted` is truthy and
+   * hasn't changed from its previous value, a `value` that the user has
+   * changed while using the app will keep that change, as long as
+   * the new `value` also matches what was given originally.
+   * Used in conjunction with `persistence_type`.
+   */
+  persistence: PropTypes.oneOfType([PropTypes.bool, PropTypes.string, PropTypes.number]),
+
+  /**
+   * Properties whose user interactions will persist after refreshing the
+   * component or the page. Since only `value` is allowed this prop can
+   * normally be ignored.
+   */
+  persisted_props: PropTypes.arrayOf(PropTypes.oneOf(['value'])),
+
+  /**
+   * Where persisted user changes will be stored:
+   * memory: only kept in memory, reset on page refresh.
+   * local: window.localStorage, data is kept after the browser quit.
+   * session: window.sessionStorage, data is cleared once the browser quit.
+   */
+  persistence_type: PropTypes.oneOf(['local', 'session', 'memory'])
 };
 
 export default withTheme(ToggleSwitch);


### PR DESCRIPTION
I added persistence for three components and would like to add more. However I was experiencing problems which I would like to resolve before continuing.

Normally it should be enough to set the attribute `persistence` to `True` to make the component
persistent with default settings. This works fine for the Slider. But for the `BooleanSwitch` and `ToggleSwitch` one always needs to add `persisted_props` and `persistence_type` attributes to make persistence work. I added the right default props for both components but somehow they don't seem to work.

**Example with BooleanSwitch**

Persistence for the following does not work:
```
daq.BooleanSwitch(id="myswitch", label="Hello World", persistence=True)
```

Persistence for the following works:
```
daq.BooleanSwitch(id="myswitch", label="Hello World", persistence=True, persisted_props=["on"], persistence_type="local"),
```
Has somebody got an idea / hint what would be the reason that defaultProps get ignored for `BooleanSwitch` and `ToggleSwitch`?