### PR TITLE
Add property to control number of digits on Gauge component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a
 Changelog](http://keepachangelog.com/en/1.0.0/) and this project
 adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- [#117](https://github.com/plotly/dash-daq/pull/117) Added `digits` prop to `Gauge` component.
+
 ## [0.5.0] - 2020-04-27
 ### Added
 - [#105](https://github.com/plotly/dash-daq/pull/105) Added [persistence](https://dash.plotly.com/persistence) for

--- a/src/components/Gauge.react.js
+++ b/src/components/Gauge.react.js
@@ -37,7 +37,8 @@ class Gauge extends React.Component {
       id,
       className,
       style,
-      theme
+      theme,
+      digits
     } = this.props;
 
     const colorValue = getColorValue(color);
@@ -60,7 +61,7 @@ class Gauge extends React.Component {
         units={units}
         css={'transform: translateY(-150%); top: 0;'}
       >
-        {logarithmic ? log.formatValue(value, base) : value.toFixed(1)}
+        {logarithmic ? log.formatValue(value, base) : value.toFixed(digits)}
       </CurrentValue>
     );
     const filteredProps = getFilteredProps(this.props);
@@ -90,7 +91,8 @@ Gauge.defaultProps = {
   max: 10,
   base: 10,
   theme: light,
-  labelPosition: 'top'
+  labelPosition: 'top',
+  digits: 1
 };
 
 Gauge.propTypes = {
@@ -138,6 +140,11 @@ Gauge.propTypes = {
    * will be displayed
    */
   showCurrentValue: PropTypes.bool,
+
+  /**
+   * Number of digits for current value
+   */
+  digits: PropTypes.number,
 
   /**
    * Label for the current value


### PR DESCRIPTION
The number of digits of the current value of the `Gauge` component is currently fixed to 1. This commit adds a new property `digits` to enable control of the number of digits, i.e. setting it to zero will show an integer value. For backwards compatibility, the default value is set to 1 (even though the javascript default value of `toFixed` is 0). This commit fixes the issue discussed in this thread,

https://community.plotly.com/t/dash-gauge-show-value-as-integer/43954

A minimal example would look like this,

```
import dash
import dash_html_components as html

from dash_daq import Gauge

app = dash.Dash()
app.layout = html.Div([Gauge(showCurrentValue=True, digits=0)],
                      style={'display': 'flex', 'alignItems': 'center', 'justifyContent': 'space-between'})

if __name__ == '__main__':
    app.run_server()

```