### PR TITLE
Updating with dockerhub auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,9 @@ jobs:
     build_and_test_node:
         docker:
             - image: circleci/python:3.7-stretch-node
-
+              auth:
+                username: dashautomation
+                password: $DASH_PAT_DOCKERHUB
         steps:
             - checkout
             - run:
@@ -41,4 +43,5 @@ workflows:
     version: 2
     build:
         jobs:
-            - build_and_test_node
+            - build_and_test_node:
+                context: dash-docker-hub


### PR DESCRIPTION

## About
- [x] I am addressing part of an issue

## Description of changes

This PR addresses the `dash-daq` component of plotly/dash-core#282, and adds authentication for Dockerhub requests for CI testing. The Circle CI `config.yml` is modified with the `dashAutomation` account details.