### PR TITLE
Update this repository for Dash 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,6 @@ ls dist/dash_daq-X.X.X.tar.gz # this is your tarball
 
 - Dash Daq HP Multimeter - [http://dash-gallery.plotly.host/dash-daq-hp-multimeter](http://dash-gallery.plotly.host/dash-daq-hp-multimeter)
 - Dash Daq IV Tracer - [http://dash-gallery.plotly.host/dash-daq-iv-tracer](http://dash-gallery.plotly.host/dash-daq-iv-tracer)
-- Dash Daq LED Control - [http://dash-gallery.plotly.host/dash-daq-led](http://dash-gallery.plotly.host/dash-daq-led)
-- Dash Daq Omega PID - [http://dash-gallery.plotly.host/dash-daq-omega-pid](http://dash-gallery.plotly.host/dash-daq-omega-pid)
 - Dash Daq Pressure Gauge KJL - [http://dash-gallery.plotly.host/dash-daq-pressure-gauge-kjl](http://dash-gallery.plotly.host/dash-daq-pressure-gauge-kjl)
 - Dash Daq Pressure Gauge Pfeiffer - [https://dash-gallery.plotly.host/dash-daq-pressure-gauge-pv](https://dash-gallery.plotly.host/dash-daq-pressure-gauge-pv)
 - Dash Daq Robotic Arm Edge - [http://dash-gallery.plotly.host/dash-daq-robotic-arm](http://dash-gallery.plotly.host/dash-daq-robotic-arm)

--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ ls dist/dash_daq-X.X.X.tar.gz # this is your tarball
 - Dash Daq IV Tracer - [http://dash-gallery.plotly.host/dash-daq-iv-tracer](http://dash-gallery.plotly.host/dash-daq-iv-tracer)
 - Dash Daq Pressure Gauge KJL - [http://dash-gallery.plotly.host/dash-daq-pressure-gauge-kjl](http://dash-gallery.plotly.host/dash-daq-pressure-gauge-kjl)
 - Dash Daq Pressure Gauge Pfeiffer - [https://dash-gallery.plotly.host/dash-daq-pressure-gauge-pv](https://dash-gallery.plotly.host/dash-daq-pressure-gauge-pv)
-- Dash Daq Robotic Arm Edge - [http://dash-gallery.plotly.host/dash-daq-robotic-arm](http://dash-gallery.plotly.host/dash-daq-robotic-arm)
 - Dash Daq Sparki - [http://dash-gallery.plotly.host/dash-daq-sparki](http://dash-gallery.plotly.host/dash-daq-sparki)
 - Dash Daq Stepper Motor - [http://dash-gallery.plotly.host/dash-daq-stepper-motor](http://dash-gallery.plotly.host/dash-daq-stepper-motor)
 - Dash Tektronix 350 - [http://dash-gallery.plotly.host/dash-daq-tektronix350](http://dash-gallery.plotly.host/dash-daq-tektronix350)

--- a/demo.py
+++ b/demo.py
@@ -604,4 +604,4 @@ def dark_update_thermometer(on):
 
 ################ Run Server ################
 if __name__ == "__main__":
-    app.run_server(debug=True)
+    app.run(debug=True)

--- a/demo.py
+++ b/demo.py
@@ -34,8 +34,7 @@ from dash_daq import (
 
 app = dash.Dash("")
 
-app.css.append_css(
-    {"external_url": "https://codepen.io/briandennis/pen/zRbYpB.css"})
+# TODO: styles are required
 
 app.config.suppress_callback_exceptions = True
 app.scripts.config.serve_locally = True

--- a/demo.py
+++ b/demo.py
@@ -1,7 +1,9 @@
-import dash
+from packaging.version import Version
 
+import dash
 print(f"Dash Version: {dash.__version__}")
-if dash.__version__ == "2.0.0":
+
+if Version(dash.__version__).major >= 2:
     from dash import html
     from dash import dcc
 else:


### PR DESCRIPTION
## Background

I was tasked with validating dash-daq functions as expected with Dash 3.0. I have found that it does! ✅ 

## Description

But the demo application needs a few updates as it has not been updated in some time. To that end, this PR incorporates three changes plus an adjustment to the linked sample apps:

1. The demo app now starts with `app.run()` rather than `app.run_server()`
2. I have revised the Dash version check to using `packaging.version` which is the more Pythonic approach
3. I have removed a broken styles reference from the demo app
4. I have removed references to demo applications that either don't run anymore, or which _do run_ but somehow link to a crypto gambling scam out of Indonesia.

Related to point three, this demo app looks quite _rough_ without styles. But I don't have a good way to retrieve the styles as they were when it was first written because the CSS file is no longer available on codepend. 

I have verified that each of the components in the demo app appears to function as expected. I have not attempted to run these components with any _hardware_. I have effectively been smoke testing that they _load_ and _render_ properly.

I also installed the developer setup and ran `npm run test` to confirm that all tests pass with Dash 3 installed.

Here is my `pip freeze` for proof:

```bash
❯ pip freeze
blinker==1.9.0
certifi==2025.1.31
charset-normalizer==3.4.1
click==8.1.8
dash==3.0.0rc4
dash-core-components==2.0.0
dash-html-components==2.0.0
Flask==3.0.3
idna==3.10
importlib_metadata==8.6.1
itsdangerous==2.2.0
Jinja2==3.1.6
MarkupSafe==3.0.2
narwhals==1.29.1
nest-asyncio==1.6.0
packaging==24.2
plotly==6.0.0
PyYAML==6.0.2
requests==2.32.3
retrying==1.3.4
setuptools==75.8.2
six==1.17.0
stringcase==1.2.0
typing_extensions==4.12.2
urllib3==2.3.0
Werkzeug==3.0.6
zipp==3.21.0
```

## Related Tickets & Documents

Closes https://github.com/plotly/dash-daq/issues/191

## Screenshots

These are the components as rendered in the demo application:

![CleanShot_Google Chrome_20250306T20 49 21@2x](https://github.com/user-attachments/assets/4e2f5272-1750-433b-b573-bedfc56dc3ee)
